### PR TITLE
Adding hostname to the log file

### DIFF
--- a/pkg/cli-utils/tm-command.go
+++ b/pkg/cli-utils/tm-command.go
@@ -11,6 +11,7 @@ import (
 
 var file string
 var all bool
+var host bool
 var current bool
 
 var TmCommands = &cli.Command{
@@ -60,6 +61,13 @@ var TmPrune = &cli.Command{
 			Usage:       "remove all previously added exclude paths from the log dir",
 			Destination: &all,
 		},
+		&cli.BoolFlag{
+			Name:        "local",
+			Aliases:     []string{"l"},
+			Usage:       "remove all previously added exclude paths from the log dir prefixed by the current host",
+			Value:       false,
+			Destination: &host,
+		},
 		&cli.StringFlag{
 			Name:        "file",
 			Aliases:     []string{"f"},
@@ -82,6 +90,8 @@ var TmPrune = &cli.Command{
 			tmutil.RemovePathsFromTM(res, buffer, verbose)
 		} else if all {
 			tmutil.RemoveAllFromLogs(logDir, buffer, verbose)
+		} else if host {
+			tmutil.RemoveAllHostRelatedFromLogs(logDir, buffer, verbose)
 		} else if file != "" {
 			tmutil.RemoveFileFromLogs(logDir, file, buffer, verbose)
 		} else {

--- a/pkg/tmutil/tmutil.go
+++ b/pkg/tmutil/tmutil.go
@@ -132,16 +132,51 @@ func removePath(path string) error {
 	return err
 }
 
-func RemoveAllFromLogs(logPath string, bufferSize int, verbose int) {
+func RemoveAllFromLogs(logDir string, bufferSize int, verbose int) {
+	logPath, err := utils.FixupPathsToHandleHome(logDir)
+	if err != nil {
+		log.Fatal(err)
+	}
 	files, err := ioutil.ReadDir(logPath)
 	if err != nil {
 		log.Fatal(err)
 	}
 	for _, file := range files {
+		if verbose > 2 {
+			log.Println("Processing: " + file.Name())
+		}
 		RemoveFileFromLogs(logPath, file.Name(), bufferSize, verbose)
 	}
 }
-func RemoveFileFromLogs(logPath string, fileName string, bufferSize int, verbose int) {
+
+func RemoveAllHostRelatedFromLogs(logDir string, bufferSize int, verbose int) {
+	logPath, err := utils.FixupPathsToHandleHome(logDir)
+	if err != nil {
+		log.Fatal(err)
+	}
+	files, err := ioutil.ReadDir(logPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	hostname, err := os.Hostname()
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, file := range files {
+		if strings.HasPrefix(file.Name(), hostname+"_") {
+			if verbose > 2 {
+				log.Println("Processing: " + file.Name())
+			}
+			RemoveFileFromLogs(logPath, file.Name(), bufferSize, verbose)
+		}
+	}
+}
+
+func RemoveFileFromLogs(logDir string, fileName string, bufferSize int, verbose int) {
+	logPath, err := utils.FixupPathsToHandleHome(logDir)
+	if err != nil {
+		log.Fatal(err)
+	}
 	file, err := os.Open(filepath.Join(logPath, fileName))
 	if err != nil {
 		log.Println(err)

--- a/pkg/tmutil/tmutil.go
+++ b/pkg/tmutil/tmutil.go
@@ -3,6 +3,7 @@ package tmutil
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"github.com/tg44/heptapod/pkg/utils"
 	"io/ioutil"
 	"log"
@@ -25,7 +26,14 @@ func AddPathsToTM(paths []string, logDir string, bufferSize int, verbose int) in
 	currentTime := time.Now()
 	defer utils.TimeTrack(currentTime, "tmutil run", verbose)
 
-	logFile, err := os.Create(filepath.Join(logPath, currentTime.Format("2006-01-02_15:04:05")+".log"))
+	hostname, err := os.Hostname()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	logFormat := "%s_%s.log"
+
+	logFile, err := os.Create(filepath.Join(logPath, fmt.Sprintf(logFormat, hostname, currentTime.Format("2006-01-02_15:04:05"))))
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
- Added the hostname to the log file format to follow the convention: ` ~/.heptapod/logs/${host}_${time}.log`
- Getting hostname using os methods and checking for error condition

Fixed #13 