### PR TITLE
Correct rule name

### DIFF
--- a/rules/osx.yaml
+++ b/rules/osx.yaml
@@ -1,4 +1,4 @@
-name: "node-multi"
+name: "osx"
 enabled: true
 searchPaths: []
 ignorePaths: []


### PR DESCRIPTION
Was copied from node-multi.yaml?

Also, since Apple calls it [macOS](https://www.apple.com/macos/), shall we use that naming here?